### PR TITLE
fix(VtkTwoView): Cut first scene source

### DIFF
--- a/src/components/VtkTwoView.vue
+++ b/src/components/VtkTwoView.vue
@@ -300,8 +300,9 @@ export default {
 
     // sync windowing and slicing to reps
     watchEffect(() => {
-      if (viewRef.value && baseImage.value) {
-        const rep = pxm.getRepresentation(baseImage.value, viewRef.value);
+      if (viewRef.value && sceneSources.value.length) {
+        const first = sceneSources.value[0];
+        const rep = pxm.getRepresentation(first, viewRef.value);
         if (rep) {
           if (rep.setSlice) rep.setSlice(currentSlice.value);
           if (rep.setWindowWidth) rep.setWindowWidth(windowing.value.width);

--- a/src/vtk/CutGeometryRepresentationProxy/index.js
+++ b/src/vtk/CutGeometryRepresentationProxy/index.js
@@ -1,9 +1,6 @@
 import macro from 'vtk.js/Sources/macro';
-
 import vtkSlicedGeometryRepresentationProxy from 'vtk.js/Sources/Proxy/Representations/SlicedGeometryRepresentationProxy';
 
-import vtkPolyDataTransformFilter from '../PolyDataTransformFilter';
-import vtkRepresentationProxyTransformMixin from '../transformMixin';
 import vtkCachedCutter from '../CachedCutter';
 
 function vtkCutGeometryRepresentationProxy(publicAPI, model) {
@@ -31,11 +28,6 @@ export function extend(publicAPI, model, initialValues = {}) {
 
   // Object methods
   vtkSlicedGeometryRepresentationProxy.extend(publicAPI, model);
-
-  vtkRepresentationProxyTransformMixin(vtkPolyDataTransformFilter)(
-    publicAPI,
-    model
-  );
 
   // Object specific methods
   vtkCutGeometryRepresentationProxy(publicAPI, model);


### PR DESCRIPTION
In the event there are no base images, setting the slice for the first
scene source is the correct behavior.