### PR TITLE
Switch to 'source-map' source maps

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -28,6 +28,7 @@ module.exports = {
       .end();
   },
   configureWebpack: {
+    devtool: 'source-map',
     resolve: {
       alias: {
         '@': __dirname,


### PR DESCRIPTION
@floryst I was unable to get the source to load correctly in the debugger. This resolves the issue for me. It would also gives us source maps in production, at the cost of slower rebuild times. 