### PR TITLE
fix: Don't display arrows unless they are needed

### DIFF
--- a/src/components/ModulePanel.vue
+++ b/src/components/ModulePanel.vue
@@ -4,7 +4,6 @@
         <v-tabs
           v-model="selectedModuleIndex"
           icons-and-text
-          show-arrows
         >
           <v-tab
             v-for="item in Modules"


### PR DESCRIPTION
@floryst This removes the arrows unless they are needed. I assume you think we should also recoup the space, which will require a like more work.