### PR TITLE
Switch to always showing arrows

### DIFF
--- a/src/components/ModulePanel.vue
+++ b/src/components/ModulePanel.vue
@@ -2,8 +2,10 @@
   <div class="height-100 d-flex flex-column">
     <div id="module-switcher" class="mt-1 mb-2">
         <v-tabs
+          id="module-switcher-tabs"
           v-model="selectedModuleIndex"
           icons-and-text
+          :show-arrows=true
         >
           <v-tab
             v-for="item in Modules"
@@ -119,5 +121,13 @@ export default defineComponent({
   flex-direction: column-reverse;
   height: 100%;
   align-items: center;
+}
+
+#module-switcher-tabs >>> .v-slide-group__prev.v-slide-group__prev--disabled {
+  visibility: hidden;
+}
+
+#module-switcher-tabs >>> .v-slide-group__next.v-slide-group__next--disabled {
+  visibility: hidden;
 }
 </style>


### PR DESCRIPTION
For some reason on mobile ( when the width getis small ) the arrows are disabled by default. Override the styling to hidden them when they are disabled.